### PR TITLE
Working bash execution and requirements

### DIFF
--- a/magi_cli.egg-info/requires.txt
+++ b/magi_cli.egg-info/requires.txt
@@ -1,1 +1,5 @@
 Click
+openai
+requests
+Pillow
+python-dotenv

--- a/magi_cli/cast.py
+++ b/magi_cli/cast.py
@@ -31,6 +31,9 @@ openai.api_key = api_key
 
 # Non-click functions
 
+def execute_bash_file(filename):
+    subprocess.run(["bash", filename], check=True)
+
 def execute_python_file(filename):
     subprocess.run([sys.executable, filename], check=True)
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup, find_packages
+from setuptools import setup, find_packages
 
 setup(
     name="magi_cli",
@@ -6,6 +7,10 @@ setup(
     packages=find_packages(),  # Automatically find all packages
     install_requires=[
         "Click",
+        "openai",
+        "requests",
+        "Pillow",
+        "python-dotenv",
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
Some solid changes:

- cast can now cast .sh files by default
- cast can now case .spell files from a .tome directory in your current directory without having to explicitly list the path
- you can now set the TOME_PATH variable to store spellcraft spells in a default location.
  - Cast will look here for .spell files by default
  - Still more work to be done for when TOME_PATH is set, but you want to explicitly list a path to a .spell file.