### PR TITLE
New Spell: Warp + CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+# Contributing to Magi CLI
+
+Thank you for your interest in contributing to Magi CLI! We welcome contributions from the community to enhance the functionality and expand the collection of spells available in Magi CLI.
+
+## Spell Format and Location
+
+To ensure that your spells function seamlessly with the `cast` command and maintain consistency within the Magi CLI project, please follow these guidelines when creating new spells:
+
+- **Location**: Spells should be located in the `./magi_cli/spells/` directory. This is the default location where the `cast` command looks for spells.
+- **File Name**: Each spell should have its own Python file with a descriptive name. For example, `fireball.py`, `warp.py`, etc.
+- **Spell Structure**: Spells should be structured as Python scripts that can be executed independently. They should have a `main` function that serves as the entry point for the spell when executed directly.
+- **Alias**: Every spell should have an alias defined at the bottom of the file, just above the `if __name__ == '__main__':` block. The alias is a short, memorable name for the spell that can be used with the `cast` command. For example: `alias = "fb"` for the fireball spell.
+- **Execution**: Spells should be executable both through the `cast` command and as individual scripts using `python magi_cli/spells/fireball.py target`. This allows users to run the spells directly if needed.
+- **Click Integration**: Spells should use the `click` library for command-line parsing and argument handling. This ensures consistency with the existing spells and allows for easy integration with the `cast` command.
+- **Documentation**: Each spell should have a docstring at the top of the file that describes its purpose, usage, and any required arguments or options. This helps users understand how to use the spell effectively.
+- **Error Handling**: Spells should include appropriate error handling and provide informative error messages to guide users when something goes wrong.
+- **Naming Conventions**: Spell names should follow the naming conventions of the Magi CLI project. Use lowercase with underscores for file names and function names, and capitalize the first letter of each word for class names.
+- **DO NOT CHANGE CAST.PY**: Do not modify the `cast.py` file directly. If you need to make changes to the `cast` command or its behavior, open an issue to discuss your proposed changes.
+
+## Spell Ideas
+
+If you have ideas for new spells that you think would be valuable additions to Magi CLI, please open an issue on the project's repository. Describe your spell idea, its purpose, and any specific requirements or considerations. The project maintainers will review your suggestion and provide feedback.
+
+## Pull Requests
+
+If you have implemented a new spell or made improvements to existing ones, you can submit a pull request to have your changes reviewed and merged into the main project. Here are the steps to create a pull request:
+
+1. Fork the Magi CLI repository to your own GitHub account.
+2. Create a new branch for your changes: `git checkout -b my-new-spell`.
+3. Implement your spell or make the necessary changes in the appropriate files.
+4. Test your changes thoroughly to ensure they work as expected and don't introduce any regressions.
+5. Commit your changes with descriptive commit messages: `git commit -m "Add new spell: My Amazing Spell"`.
+6. Push your changes to your forked repository: `git push origin my-new-spell`.
+7. Open a pull request on the main Magi CLI repository, providing a clear description of your changes and any relevant information.
+8. The project maintainers will review your pull request, provide feedback if necessary, and merge your changes if they align with the project's goals and guidelines.
+
+Thank you for contributing to Magi CLI and helping to expand the realm of arcane computing!

--- a/README.md
+++ b/README.md
@@ -50,6 +50,14 @@ Commands are designed with a few things in mind:
 
 9. **Exile** - ('**ex**')Banish a file or directory to the /tmp or C:\temp directory in a realm called .exile. This allows for the removal of a file from your root directory without getting rid of it completely.
 
+10. **Warp**: ('**wp**') Warp to remote SSH sessions with ease. This command allows you to manage and connect to SSH sessions effortlessly. It provides a user-friendly interface to register new SSH sessions, edit existing ones, and quickly connect to them. With Warp, you can:
+   - List all registered SSH sessions
+   - Choose a session to connect to
+   - Add a new SSH session by providing the host, username, and optional private key
+   - Generate a new RSA key pair for authentication or use an existing private key
+   - Delete an existing SSH session and its associated keys
+   - Bypass the session selection and directly connect to a session using its alias
+
 ##### Future Spells
 
 1. **Unseen_Servant**: ('**uss**') Enlist an ethereal ally to cast spells at regular intervals. Can invoke any '.spell' scroll on a schedule. This command schedules a spell to be cast on a regular basis, allowing you to automate tasks by running any '.spell' file on a schedule. (WIP)
@@ -96,11 +104,11 @@ Additional spells, file type support, and arcane features can be added to the CL
 
 #### Spell Improvements
 
-- Spellcraft: Allow the use of arcane variables in '.spell' scrolls for more dynamic spell weaving. I want spellcraft to be a versatile tool that can be used to accomplish more than just basic tasks without having to go too far into specifics on the users side. I'd like to eventually design a 'recording' system that can remember your next few commands.
+- Spellcraft: Allow the use of arcane variables in '.spell' scrolls for more dynamic spell weaving. I want spellcraft to be a versatile tool that can be used to accomplish more than just basic tasks without having to go too far into specifics on the users side. I'd like to eventually design a 'recording' system that can remember your last few commands.
 
 - Runecraft: Implement a way to save runes to a tome directory and allow them to be executed from the CLI. Allow runes to be saved as .spell files. Something like that.
 
-- Astral_Realm: We need to figure out if flask is all we need backend wise.
+- Astral_Realm: We need to figure out if flask is all we need backend wise. Also looking into FastUI and FastAPI.
 
 #### General Improvements
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Another goal for cast is to serve as a universal execution command. I despise ha
 
 ##### Tenets
 
-Commands are designed with a few things in mind:
+Spells are designed with a few things in mind:
 
 - Effectiveness - They need to work. Half functioning spells won't be included in a release version.
 - Flavorfulness - They need to feel like magic. They should work in a manner that does not require memorization besides magic words and a target unless a flavorful way to add more features can be devised.
-- Modular - They need to fit into Magi_CLI in a fully functional way. If you can't both cast it with `cast spell target` or `python path/to/spell.py target`, it is not acceptable. Each command should be both executable and castable as both file and command.
+- Modulararity - They need to fit into Magi_CLI in a fully functional way. If you can't both cast it with `cast spell target` or `python path/to/spell.py target`, it is not acceptable. Each command should be both executable and castable as both file and command.
 - Innovative - A spell will not be accepted if it only performs a task that a UNIX command already performs. We're crafting spells here, not reworking old ground.
 - Fun! - They should be enjoyable to use! Keep the debug messages in theme, keep the soul of the project alive!
 
@@ -123,3 +123,7 @@ Additional spells, file type support, and arcane features can be added to the CL
 2. **MAGI_CLI Sanctum** - This is an IDE for MAGI_CLI that responds to casting spells and creating commands with animations and sound effects. It will have the same goal as the CLI itself, which is to both have fun functionality and to supercharge your terminal experience.
 
 3. **MAGI_CLI VSCode Extension** - This will be an extension that allows you to have the fun and functionality of MAGI_CLI in VSCode. I want to incorporate the animations and sound effects from the Sanctum into this extension.
+
+### Contributing
+
+If you would like to contribute to the project, please read the [CONTRIBUTING.md](CONTRIBUTING.md) file for more information.

--- a/magi_cli/cast.py
+++ b/magi_cli/cast.py
@@ -95,17 +95,17 @@ def cast(input):
 
     elif input[0] in aliases:
         command = aliases[input[0]]
-        ctx = click.get_current_context()  # Define ctx here
+        ctx = click.get_current_context()
         if len(input) > 1:
-            ctx.invoke(command, file_paths=input[1:])
+            ctx.invoke(command, args=input[1:])
         else:
             ctx.invoke(command)
-
     elif input[0] in cli.commands:
-        ctx = click.get_current_context()  # Define ctx here
+        ctx = click.get_current_context()
         command = cli.commands[input[0]]
         if len(input) > 1:
-            ctx.invoke(command, file_paths=input[1:])
+            # Ensure the arguments are passed correctly
+            ctx.invoke(command, args=input[1:])
         else:
             ctx.invoke(command)
 

--- a/magi_cli/cast.py
+++ b/magi_cli/cast.py
@@ -73,7 +73,7 @@ def execute_spell_file(spell_file):
 
 @click.command()
 @click.argument('input', nargs=-1)
-def cast(input):
+def cast(input, **kwargs):
     input = list(input)  # Convert input into a list to separate command and arguments
 
     # Use SANCTUM_PATH for the .tome directory
@@ -99,7 +99,10 @@ def cast(input):
         if len(input) > 1:
             ctx.invoke(command, args=input[1:])
         else:
-            ctx.invoke(command)
+            if 'alias' in kwargs:
+                ctx.invoke(command, alias=kwargs['alias'])
+            else:
+                ctx.invoke(command)
     elif input[0] in cli.commands:
         ctx = click.get_current_context()
         command = cli.commands[input[0]]
@@ -107,7 +110,10 @@ def cast(input):
             # Ensure the arguments are passed correctly
             ctx.invoke(command, args=input[1:])
         else:
-            ctx.invoke(command)
+            if 'alias' in kwargs:
+                ctx.invoke(command, alias=kwargs['alias'])
+            else:
+                ctx.invoke(command)
 
     else:
         # Check if the input is a file and execute accordingly

--- a/magi_cli/spells/aether_inquiry.py
+++ b/magi_cli/spells/aether_inquiry.py
@@ -59,7 +59,7 @@ def send_message(message_log):
     if client:
         # Use the OpenAI API to send the message
         response = client.chat.completions.create(
-            model="gpt-4-1106-preview",  # or your desired model
+            model="gpt-4-turbo-preview",  # or your desired model
             messages=message_log,
             max_tokens=1500,
             temperature=0.7,
@@ -72,8 +72,8 @@ def send_message(message_log):
         return "OpenAI API key is not set. Unable to consult the aether for wisdom."
 
 @click.command()
-@click.argument('file_paths', nargs=-1)  # Accepts multiple file paths
-def aether_inquiry(file_paths):
+@click.argument('args', nargs=-1)  # Accepts multiple file paths
+def aether_inquiry(args):
     """ 'ai' - Call upon the arcane intellect of an artificial intelligence to answer your questions and generate spells or Python scripts."""
 
     message_log = [
@@ -111,8 +111,8 @@ def aether_inquiry(file_paths):
                     
 
     # Check if any file paths are provided
-    if file_paths:
-        for file_path in file_paths:
+    if args:
+        for file_path in args:
             if os.path.isdir(file_path):
                 # Ask user if they want to transcribe directory contents
                 transcribe_confirm = input(f"Do you want to transcribe the contents of the directory '{file_path}' to the .aether directory? (yes/no): ")

--- a/magi_cli/spells/banish.py
+++ b/magi_cli/spells/banish.py
@@ -3,16 +3,16 @@ import os
 import shutil
 
 @click.command()
-@click.argument('file_paths', nargs=-1, required=True)  # Accepts multiple file paths
-def banish(file_paths):
+@click.argument('args', nargs=-1, required=True)  # Accepts multiple file paths
+def banish(args):
     ''' 'bn' - Banish a target to the /tmp directory in a .exile folder. If no /tmp directory exists, place it in a C:\\temp\\.exile directory.'''
     
-    if not file_paths:
+    if not args:
         click.echo("Error: No file path provided.")
         return
 
     # Handle the first file path from the list
-    file_path = file_paths[0]
+    file_path = args[0]
 
     # Check if /tmp exists (Unix systems) or use C:\temp (Windows)
     if os.path.exists("/tmp"):

--- a/magi_cli/spells/divine.py
+++ b/magi_cli/spells/divine.py
@@ -4,11 +4,11 @@ import fnmatch
 from datetime import datetime
 
 @click.command()
-@click.argument('file_paths', nargs=-1, required=False)  # Use file_paths to accept variable number of arguments
-def divine(file_paths):
+@click.argument('args', nargs=-1, required=False)  # Use args to accept variable number of arguments
+def divine(args):
     """ 'dv' - List the directory contents with detailed information, or find a file anywhere below the root directory, searching through child directories, and echo its path."""
     
-    search_term = file_paths[0] if file_paths else None
+    search_term = args[0] if args else None
 
     if search_term:
         click.echo(f"You cast your senses into the ether, seeking knowledge of the realm...\n")

--- a/magi_cli/spells/fireball.py
+++ b/magi_cli/spells/fireball.py
@@ -4,8 +4,8 @@ import shutil
 from magi_cli.spells import SANCTUM_PATH 
 
 @click.command()
-@click.argument('file_paths', nargs=-1, required=True)  # Accept multiple file paths
-def fireball(file_paths):
+@click.argument('args', nargs=-1, required=True)  # Accept multiple file paths
+def fireball(args):
     """ 'fb' - Deletes a directory or file."""
     graveyard_path = os.path.join(SANCTUM_PATH, '.graveyard')
 
@@ -14,7 +14,7 @@ def fireball(file_paths):
         click.echo("There are no graveyards available. Unable to cast fireball.")
         return  # Break out of the function
 
-    for file_path in file_paths:  # Iterate over each file path provided
+    for file_path in args:  # Iterate over each file path provided
         if os.path.exists(file_path):
             click.echo(f"Your hands tremble as you draw upon the arcane energies...\n")
 

--- a/magi_cli/spells/necromancy.py
+++ b/magi_cli/spells/necromancy.py
@@ -3,8 +3,8 @@ import os
 from magi_cli.spells import SANCTUM_PATH 
 
 @click.command()
-@click.argument('file_paths', nargs=-1, required=False)  # Accepts any number of arguments but doesn't use them
-def necromancy(file_paths):
+@click.argument('args', nargs=-1, required=False)  # Accepts any number of arguments but doesn't use them
+def necromancy(args):
     """ 'nc' - Start a session that keeps a memory of deleted files."""
     graveyard_path = os.path.join(SANCTUM_PATH, '.graveyard')
     try:

--- a/magi_cli/spells/ponder.py
+++ b/magi_cli/spells/ponder.py
@@ -6,12 +6,12 @@ import glob
 from magi_cli.spells import SANCTUM_PATH 
 
 @click.command()
-@click.argument('file_paths', nargs=-1, required=False)  # Accepts a variable number of arguments
-def ponder(file_paths):
+@click.argument('args', nargs=-1, required=False)  # Accepts a variable number of arguments
+def ponder(args):
     """ 'pd' - Ponders a specific file or all spells in the .orb directory."""
     orb_dir = os.path.join(SANCTUM_PATH, '.orb')
 
-    file = file_paths[0] if file_paths else None  # Extract file name if provided
+    file = args[0] if args else None  # Extract file name if provided
     if file:
         # If a file argument was supplied, check if it exists in the current directory
         if os.path.exists(file):

--- a/magi_cli/spells/raise_dead.py
+++ b/magi_cli/spells/raise_dead.py
@@ -4,12 +4,12 @@ import shutil
 from magi_cli.spells import SANCTUM_PATH  # Import SANCTUM_PATH
 
 @click.command()
-@click.argument('file_paths', nargs=-1, required=False)  # Accepts a variable number of arguments
-def raise_dead(file_paths):
+@click.argument('args', nargs=-1, required=False)  # Accepts a variable number of arguments
+def raise_dead(args):
     """ 'rd' - Restore a spirit from the graveyard."""
     graveyard_path = os.path.join(SANCTUM_PATH, '.graveyard')  # Use SANCTUM_PATH for .graveyard directory
 
-    spirit = file_paths[0] if file_paths else None
+    spirit = args[0] if args else None
 
     if spirit:
         # Handle a specific spirit

--- a/magi_cli/spells/runecraft.py
+++ b/magi_cli/spells/runecraft.py
@@ -46,13 +46,13 @@ def create_circular_mask(image):
     return mask
 
 @click.command()
-@click.argument('file_paths', nargs=-1, required=True)  # Accepts multiple file paths
-def runecraft(file_paths):
+@click.argument('args', nargs=-1, required=True)  # Accepts multiple file paths
+def runecraft(args):
     ''' 'rc' - Generate a GUI for a Bash script in the form of an enchanted rune.'''
 
     # Correctly handle the first file path from the list
-    if file_paths:
-        file_path = file_paths[0]
+    if args:
+        file_path = args[0]
         base_filename = os.path.basename(file_path)
     else:
         # Handle the case where no file path is provided

--- a/magi_cli/spells/spellcraft.py
+++ b/magi_cli/spells/spellcraft.py
@@ -5,15 +5,15 @@ from magi_cli.spells import SANCTUM_PATH  # Import SANCTUM_PATH
 @click.command()
 @click.argument('num_commands', type=int, required=False)
 @click.argument('spell_file', required=False)
-@click.argument('file_paths', nargs=-1, required=False)
-def spellcraft(num_commands=None, spell_file=None, file_paths=None):
+@click.argument('args', nargs=-1, required=False)
+def spellcraft(num_commands=None, spell_file=None, args=None):
     """ 'sc' - Create a macro spell and store it in .tome."""
     # Check if num_commands and spell_file are provided directly
     if num_commands is None or spell_file is None:
-        if file_paths and len(file_paths) >= 1:
+        if args and len(args) >= 1:
             try:
-                num_commands = int(file_paths[0])
-                spell_file = file_paths[1]
+                num_commands = int(args[0])
+                spell_file = args[1]
             except (ValueError, IndexError):
                 click.echo("Error: Invalid arguments provided to spellcraft. Example: `cast sc 3 test_spell`")
                 return

--- a/magi_cli/spells/warp.py
+++ b/magi_cli/spells/warp.py
@@ -22,7 +22,7 @@ def warp(ctx, args):
             alias = list(sessions.keys())[int(selected_session) - 1]
             connect_to_host(sessions[alias])
         else:
-            click.echo("The arcane forces have granted you passage. Bypassing the mystical session selection.")
+            click.echo("Bypassing the mystical session selection.")
         ctx.exit()
 
     alias = args[0]

--- a/magi_cli/spells/warp.py
+++ b/magi_cli/spells/warp.py
@@ -1,0 +1,98 @@
+import click
+import os
+import subprocess
+import json
+from getpass import getpass
+from magi_cli.spells import SANCTUM_PATH
+
+# Define the path for the .circle file within the SANCTUM_PATH
+CIRCLE_PATH = os.path.join(SANCTUM_PATH, '.circle')
+
+@click.group()
+def warp():
+    """Warp to SSH sessions with ease."""
+    pass
+
+@warp.command()
+@click.argument('alias', required=False)
+def connect(alias):
+    """Connect to a saved SSH session."""
+    # Ensure the .circle file exists
+    if not os.path.exists(CIRCLE_PATH):
+        os.makedirs(os.path.dirname(CIRCLE_PATH), exist_ok=True)
+        with open(CIRCLE_PATH, 'w') as f:
+            json.dump({}, f)
+
+    # Load the saved SSH sessions from the .circle file
+    with open(CIRCLE_PATH, 'r') as f:
+        sessions = json.load(f)
+
+    if alias:
+        # If an alias is provided, warp to that SSH session
+        if alias in sessions:
+            session = sessions[alias]
+            ssh_command = ['ssh']
+            if 'key' in session:
+                ssh_command.extend(['-i', session['key']])
+            if 'password' in session:
+                ssh_command.extend(['-o', f'PasswordAuthentication=yes'])
+            ssh_command.append(f"{session['user']}@{session['host']}")
+            subprocess.run(ssh_command)
+        else:
+            click.echo(f"No saved session for alias '{alias}'")
+            if click.confirm("Would you like to register this new host?"):
+                register_host(alias)
+    else:
+        # If no alias is provided, list all saved SSH sessions
+        click.echo("Available SSH sessions:")
+        for alias, details in sessions.items():
+            click.echo(f"- {alias}: {details['user']}@{details['host']}")
+
+@warp.command()
+@click.argument('alias', required=False)
+def register(alias):
+    """Register a new SSH session."""
+    if not alias:
+        alias = click.prompt("Enter a nickname for the new host")
+    register_host(alias)
+
+def register_host(alias):
+    """Helper function to register a new host."""
+    host = click.prompt("Enter the host IP or hostname")
+    user = click.prompt("Enter the username")
+    password = None
+    if click.confirm("Do you want to set a password?"):
+        password = getpass("Enter the password")
+    key = None
+    if click.confirm("Do you want to set a private key?"):
+        key = click.prompt("Enter the private key location")
+
+    # Load or create the .circle file
+    if not os.path.exists(CIRCLE_PATH):
+        os.makedirs(os.path.dirname(CIRCLE_PATH), exist_ok=True)
+        sessions = {}
+    else:
+        with open(CIRCLE_PATH, 'r') as f:
+            sessions = json.load(f)
+
+    # Add the new session to the .circle file
+    sessions[alias] = {
+        "user": user,
+        "host": host,
+        "password": password,
+        "key": key
+    }
+
+    with open(CIRCLE_PATH, 'w') as f:
+        json.dump(sessions, f, indent=2)
+    click.echo(f"Host '{alias}' registered successfully.")
+
+warp.add_command(connect)
+warp.add_command(register)
+
+# Set the alias for the warp spell
+alias = "wp"
+
+# Add the warp spell to the incantations
+if __name__ == '__main__':
+    warp()

--- a/magi_cli/spells/warp.py
+++ b/magi_cli/spells/warp.py
@@ -1,56 +1,184 @@
-import click
 import os
-import subprocess
+import click
+import paramiko
 import json
-from magi_cli.spells import SANCTUM_PATH
+import subprocess
+import time
+from threading import Lock
+from cryptography.hazmat.primitives import serialization as crypto_serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.backends import default_backend as crypto_default_backend
 
 # Define the path for the .circle file within the SANCTUM_PATH
+SANCTUM_PATH = os.getenv('SANCTUM_PATH', os.path.expanduser('~/.sanctum'))
 CIRCLE_PATH = os.path.join(SANCTUM_PATH, '.circle')
+KEY_PATH = os.path.join(SANCTUM_PATH, 'keys')
+circle_lock = Lock()
+
+# Ensure the SANCTUM_PATH exists
+os.makedirs(SANCTUM_PATH, exist_ok=True)
+os.makedirs(KEY_PATH, exist_ok=True)
 
 @click.group(invoke_without_command=True)
 @click.argument('args', nargs=-1)
 @click.pass_context
 def warp(ctx, args):
     """ 'wp' - Warp to remote SSH sessions with ease."""
+    alias = None if not args else args[0]
     sessions = load_sessions()
 
-    if not args:
-        click.echo("Behold, the available SSH sessions:")
-        list_sessions(sessions)
-        selected_session = click.prompt("Choose a session number (or press Enter to bypass the mystical selection)", default="")
-        if selected_session.isdigit() and int(selected_session) <= len(sessions):
-            alias = list(sessions.keys())[int(selected_session) - 1]
+    while True:
+        if not alias:
+            list_sessions(sessions)
+            selected_session = click.prompt("Choose a session number or 'E' to edit the circle", default="")
+            if selected_session.upper() == 'E':
+                result = delete_session(sessions)
+                if result == 'WARP':
+                    continue
+                return
+            elif selected_session.isdigit() and int(selected_session) <= len(sessions):
+                alias = list(sessions.keys())[int(selected_session) - 1]
+            else:
+                click.echo("Bypassing the mystical session selection.")
+                continue
+
+        if alias in sessions:
+            click.echo(f"Warping to {alias}...")
             connect_to_host(sessions[alias])
         else:
-            click.echo("Bypassing the mystical session selection.")
+            if click.confirm(f"Host '{alias}' not found in your teleportation circle. Would you like to register it and forge a mystical connection?"):
+                sessions[alias] = register_host(alias, sessions)
+                save_sessions(sessions)
+            else:
+                click.echo("The arcane energies remain undisturbed. Operation cancelled.")
         ctx.exit()
 
-    alias = args[0]
+def generate_rsa_keys(alias):
+    private_key_path = os.path.join(KEY_PATH, f'{alias}.pem')
+    public_key_path = f"{private_key_path}.pub"
 
-    if alias in sessions:
-        connect_to_host(sessions[alias])
+    if not os.path.exists(private_key_path):
+        key = rsa.generate_private_key(
+            backend=crypto_default_backend(),
+            public_exponent=65537,
+            key_size=2048
+        )
+        private_key = key.private_bytes(
+            crypto_serialization.Encoding.PEM,
+            crypto_serialization.PrivateFormat.PKCS8,
+            crypto_serialization.NoEncryption()
+        )
+        public_key = key.public_key().public_bytes(
+            crypto_serialization.Encoding.OpenSSH,
+            crypto_serialization.PublicFormat.OpenSSH
+        )
+
+        with open(private_key_path, 'wb') as f:
+            f.write(private_key)
+
+        with open(public_key_path, 'wb') as f:
+            f.write(public_key)
+
+        click.echo(f"A new talisman has been forged in secrecy: {private_key_path}")
     else:
-        if click.confirm(f"Host '{alias}' not found in your teleportation circle. Would you like to register it and forge a mystical connection?"):
-            sessions[alias] = register_host(alias)
-            save_sessions(sessions)
-            click.echo(f"The ancient forces have aligned, and the realm of '{alias}' is now bound to your essence.")
-        else:
-            click.echo("The arcane energies remain undisturbed. Operation cancelled.")
+        click.echo(f"The talisman already exists: {private_key_path}")
 
+    return private_key_path
+
+# Function to append public key to authorized_keys on the server
+def append_public_key_to_authorized_keys(hostname, username, private_key_path):
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh.load_system_host_keys()
+
+    try:
+        ssh.connect(hostname=hostname, username=username, key_filename=private_key_path)
+        click.echo("Connected to host to append public key.")
+        
+        public_key_path = f"{private_key_path}.pub"
+        with open(public_key_path, 'r') as public_key_file:
+            public_key = public_key_file.read()
+            ssh.exec_command(f'echo "{public_key}" >> ~/.ssh/authorized_keys')
+            click.echo("Public key appended to remote authorized_keys.")
+    except Exception as e:
+        click.echo(f"Error appending public key: {e}")
+    finally:
+        ssh.close()
+
+# Load existing sessions from CIRCLE_PATH
 def load_sessions():
-    if os.path.exists(CIRCLE_PATH):
-        with open(CIRCLE_PATH, 'r') as f:
-            return json.load(f)
-    return {}
+    with circle_lock:
+        if os.path.exists(CIRCLE_PATH):
+            with open(CIRCLE_PATH, 'r', encoding='utf-8') as f:
+                return json.load(f)
+        return {}
+
+# List all registered sessions
+def list_sessions(sessions):
+    if not sessions:
+        click.echo("Your teleportation circle is empty. Invoke 'warp' with an alias to connect or register.")
+        return
+    for i, (alias, details) in enumerate(sessions.items(), start=1):
+        if details is not None:
+            click.echo(f"{i}. {alias}: {details['user']}@{details['host']}")
+        else:
+            click.echo(f"{i}. {alias}: No details available")
+
+# Delete a session
+def delete_session(sessions):
+    while True:  # Keep showing the sessions until the user decides to quit
+        list_sessions(sessions)
+        selected_option = click.prompt("Enter the number of the session you want to delete or 'W' to return to warp selection", default="W")
+
+        if selected_option.upper() == 'W':
+            return 'WARP'  # Signal to return to the warp menu
+
+        if selected_option.isdigit() and int(selected_option) <= len(sessions):
+            session_alias = list(sessions.keys())[int(selected_option) - 1]
+            del sessions[session_alias]
+            click.echo(f"The arcane link to '{session_alias}' has been severed.")
+            # Save the updated sessions back to the file
+            save_sessions(sessions)
+        else:
+            click.echo("Invalid selection. Please choose a valid session number or 'Q' to quit.")
+
+def register_host(alias, sessions):
+    """Register a new SSH session with arcane energies."""
+    click.echo(f"By the ancient rite of binding, we shall link your essence to another realm...")
+    host = click.prompt("Envision the realm's address (Enter the host IP or hostname)")
+    user = click.prompt("Whisper the name of your alter ego in that realm (Enter the username)")
+    
+    key_choice = click.prompt("Do you possess a talisman to bypass the guardians? (Do you want to set or generate a private key?) [G/P]", default="G", show_default=False)
+    
+    key = None
+    if key_choice.upper() == 'G':
+        key = generate_rsa_keys(alias)
+        append_public_key_to_authorized_keys(host, user, key)
+        click.echo("Attempting to bind the talisman with the distant realm...")
+        # Attempt to bind the talisman with the distant realm code goes here
+        click.echo(f"The talisman has been bound to {user}@{host}.")
+    elif key_choice.upper() == 'P':
+        key = click.prompt("Reveal the talisman's hiding place (Enter the private key location)")
+    else:
+        click.echo("The arcane forces are puzzled by your choice. No talisman will be set.")
+
+    # Ensure the .circle file exists and update it with the new host information
+    sessions[alias] = {"user": user, "host": host, "key": key}
+    save_sessions(sessions)
+    
+    click.echo(f"The winds of magic swirl and solidify; a new passage to '{alias}' has been established.")
 
 def save_sessions(sessions):
-    os.makedirs(os.path.dirname(CIRCLE_PATH), exist_ok=True)
-    with open(CIRCLE_PATH, 'w') as f:
-        json.dump(sessions, f, indent=4)
+    with circle_lock:
+        os.makedirs(os.path.dirname(CIRCLE_PATH), exist_ok=True)
+        with open(CIRCLE_PATH, 'w') as f:
+            json.dump(sessions, f, indent=2)
+            click.echo(f"Host '{alias}' registered successfully.")
 
-def list_sessions(sessions):
-    for alias, details in sessions.items():
-        click.echo(f"{alias}: {details['user']}@{details['host']}")
+        # Debugging: Verify the contents right after writing and sleeping
+        with open(CIRCLE_PATH, 'r', encoding='utf-8') as f:
+            file_contents = f.read()
+        print(f"File contents immediately after saving and sleeping: {file_contents}")  # Debug line
 
 def connect_to_host(session):
     ssh_command = ['ssh']
@@ -59,35 +187,29 @@ def connect_to_host(session):
     ssh_command.append(f"{session['user']}@{session['host']}")
     subprocess.run(ssh_command)
 
-def register_host(alias):
-    """Register a new SSH session with arcane energies."""
-    click.echo("By the ancient rite of binding, we shall link your essence to another realm...")
-    host = click.prompt("Envision the realm's address (Enter the host IP or hostname)")
-    user = click.prompt("Whisper the name of your alter ego in that realm (Enter the username)")
-    
-    key = None
-    if click.confirm("Do you possess a talisman to bypass the guardians? (Do you want to set or generate a private key?)"):
-        key_choice = click.prompt("Press 'G' to generate a new talisman or 'P' to provide the path to an existing one (G/P)", default="G")
-        if key_choice.upper() == 'G':
-            key = os.path.expanduser("~/.ssh/warp_circle.pem")
-            if not os.path.exists(key):
-                click.echo("Generating the talisman...")
-                os.system(f"ssh-keygen -t rsa -b 4096 -f {key} -N ''")
-                click.echo(f"A new talisman has been forged in secrecy: {key}")
-            else:
-                click.echo(f"The talisman already exists: {key}")
-        elif key_choice.upper() == 'P':
-            key = click.prompt("Reveal the talisman's hiding place (Enter the private key location)")
+@warp.command()
+@click.argument('alias')
+def connect(alias):
+    sessions = load_sessions()
+    if alias not in sessions:
+        click.echo("This realm is unknown to the arcane forces.")
+        return
+    session = sessions[alias]
+    ssh = paramiko.SSHClient()
+    ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    try:
+        if 'key' in session:
+            key_path = os.path.expanduser(session['key'])
+            key = paramiko.RSAKey.from_private_key_file(key_path)
+            ssh.connect(session['host'], username=session['user'], pkey=key)
         else:
-            click.echo("Invalid choice. No talisman will be set.")
-
-        if key:
-            click.echo("Attempting to bind the talisman with the distant realm...")
-            os.system(f"ssh-copy-id -i {key}.pub {user}@{host}")
-            click.echo(f"The talisman has been bound to {user}@{host}.")
-
-    click.echo(f"The winds of magic swirl and solidify; a new passage to '{alias}' has been established.")
-    return {"user": user, "host": host, "key": key}
+            ssh.connect(session['host'], username=session['user'])
+        click.echo(f"Connected to {alias}.")
+        # This part is for demonstration. You might want to implement a full shell or another interaction.
+        stdin, stdout, stderr = ssh.exec_command('whoami')
+        click.echo(stdout.read().decode())
+    finally:
+        ssh.close()
 
 alias = "wp"
 

--- a/magi_cli/spells/warp.py
+++ b/magi_cli/spells/warp.py
@@ -17,6 +17,12 @@ def warp(ctx, args):
     if not args:
         click.echo("Available SSH sessions:")
         list_sessions(sessions)
+        selected_session = click.prompt("Select a session number (or press Enter to bypass)", default="")
+        if selected_session.isdigit() and int(selected_session) <= len(sessions):
+            alias = list(sessions.keys())[int(selected_session) - 1]
+            connect_to_host(sessions[alias])
+        else:
+            click.echo("Bypassing session selection.")
         ctx.exit()
 
     alias = args[0]

--- a/magi_cli/spells/warp.py
+++ b/magi_cli/spells/warp.py
@@ -8,72 +8,51 @@ from magi_cli.spells import SANCTUM_PATH
 # Define the path for the .circle file within the SANCTUM_PATH
 CIRCLE_PATH = os.path.join(SANCTUM_PATH, '.circle')
 
-@click.group()
-def warp():
+@click.group(invoke_without_command=True)
+@click.argument('args', nargs=-1)
+@click.pass_context
+def warp(ctx, args):
     """ 'wp' - Warp to remote SSH sessions with ease."""
-    pass
-
-@warp.command()
-@click.argument('alias', required=False)
-def connect(alias, **kwargs):
-    """Connect to a saved SSH session."""
-    # Ensure the .circle file exists
-    if not os.path.exists(CIRCLE_PATH):
-        os.makedirs(os.path.dirname(CIRCLE_PATH), exist_ok=True)
-        with open(CIRCLE_PATH, 'w') as f:
-            json.dump({}, f)
-
     # Load the saved SSH sessions from the .circle file
-    with open(CIRCLE_PATH, 'r') as f:
-        sessions = json.load(f)
-
-    if alias:
-        # If an alias is provided, warp to that SSH session
-        if alias in sessions:
-            session = sessions[alias]
-            ssh_command = ['ssh']
-            if 'key' in session:
-                ssh_command.extend(['-i', session['key']])
-            if 'password' in session:
-                ssh_command.extend(['-o', f'PasswordAuthentication=yes'])
-            ssh_command.append(f"{session['user']}@{session['host']}")
-            subprocess.run(ssh_command)
-        else:
-            click.echo(f"No saved session for alias '{alias}'")
-            if click.confirm("Would you like to register this new host?"):
-                register_host(alias)
-    else:
-        # If no alias is provided, list all saved SSH sessions
-        click.echo("Available SSH sessions:")
-        for alias, details in sessions.items():
-            click.echo(f"- {alias}: {details['user']}@{details['host']}")
-
-@warp.command()
-@click.argument('alias', required=False)
-def register(alias):
-    """Register a new SSH session."""
-    if not alias:
-        alias = click.prompt("Enter a nickname for the new host")
-    register_host(alias)
-
-def register_host(alias):
-    """Helper function to register a new host."""
-    host = click.prompt("Enter the host IP or hostname")
-    user = click.prompt("Enter the username")
-    password = None
-    if click.confirm("Do you want to set a password?"):
-        password = getpass("Enter the password")
-    key = None
-    if click.confirm("Do you want to set a private key?"):
-        key = click.prompt("Enter the private key location")
-
-    # Load or create the .circle file
-    if not os.path.exists(CIRCLE_PATH):
-        os.makedirs(os.path.dirname(CIRCLE_PATH), exist_ok=True)
-        sessions = {}
-    else:
+    if os.path.exists(CIRCLE_PATH):
         with open(CIRCLE_PATH, 'r') as f:
             sessions = json.load(f)
+    else:
+        sessions = {}
+
+    if not args:
+        # If no args are provided, show the help message.
+        print(ctx.get_help())
+        return
+
+    alias = args[0]
+
+    if alias in sessions:
+        # If an alias is provided and found, connect to that SSH session
+        connect_to_host(sessions[alias])
+    else:
+        # If the alias is not found, go through registration wizard
+        if click.confirm(f"Host '{alias}' not found. Would you like to register it?"):
+            register_host(alias, sessions)
+        else:
+            click.echo("Operation cancelled.")
+
+def connect_to_host(session):
+    """Connect to a saved SSH session."""
+    ssh_command = ['ssh']
+    if 'key' in session:
+        ssh_command.extend(['-i', session['key']])
+    if 'password' in session:
+        ssh_command.extend(['-o', 'PasswordAuthentication=yes'])
+    ssh_command.append(f"{session['user']}@{session['host']}")
+    subprocess.run(ssh_command)
+
+def register_host(alias, sessions):
+    """Register a new SSH session."""
+    host = click.prompt("Enter the host IP or hostname")
+    user = click.prompt("Enter the username")
+    password = getpass("Enter the password") if click.confirm("Do you want to set a password?") else None
+    key = click.prompt("Enter the private key location") if click.confirm("Do you want to set a private key?") else None
 
     # Add the new session to the .circle file
     sessions[alias] = {
@@ -83,16 +62,13 @@ def register_host(alias):
         "key": key
     }
 
+    # Ensure the .circle file exists
+    if not os.path.exists(CIRCLE_PATH):
+        os.makedirs(os.path.dirname(CIRCLE_PATH), exist_ok=True)
+
     with open(CIRCLE_PATH, 'w') as f:
         json.dump(sessions, f, indent=2)
     click.echo(f"Host '{alias}' registered successfully.")
 
-warp.add_command(connect)
-warp.add_command(register)
-
-# Set the alias for the warp spell
-alias = "wp"
-
-# Add the warp spell to the incantations
 if __name__ == '__main__':
     warp()

--- a/magi_cli/spells/warp.py
+++ b/magi_cli/spells/warp.py
@@ -10,7 +10,7 @@ CIRCLE_PATH = os.path.join(SANCTUM_PATH, '.circle')
 
 @click.group()
 def warp():
-    """Warp to SSH sessions with ease."""
+    """ 'wp' - Warp to remote SSH sessions with ease."""
     pass
 
 @warp.command()

--- a/magi_cli/spells/warp.py
+++ b/magi_cli/spells/warp.py
@@ -15,7 +15,7 @@ def warp():
 
 @warp.command()
 @click.argument('alias', required=False)
-def connect(alias):
+def connect(alias, **kwargs):
     """Connect to a saved SSH session."""
     # Ensure the .circle file exists
     if not os.path.exists(CIRCLE_PATH):

--- a/magi_cli/spells/warp.py
+++ b/magi_cli/spells/warp.py
@@ -66,9 +66,26 @@ def register_host(alias):
     user = click.prompt("Whisper the name of your alter ego in that realm (Enter the username)")
     
     key = None
-    if click.confirm("Do you possess a talisman to bypass the guardians? (Do you want to set a private key?)"):
-        key = click.prompt("Reveal the talisman's hiding place (Enter the private key location)")
-    
+    if click.confirm("Do you possess a talisman to bypass the guardians? (Do you want to set or generate a private key?)"):
+        key_choice = click.prompt("Press 'G' to generate a new talisman or 'P' to provide the path to an existing one (G/P)", default="G")
+        if key_choice.upper() == 'G':
+            key = os.path.expanduser("~/.ssh/warp_circle.pem")
+            if not os.path.exists(key):
+                click.echo("Generating the talisman...")
+                os.system(f"ssh-keygen -t rsa -b 4096 -f {key} -N ''")
+                click.echo(f"A new talisman has been forged in secrecy: {key}")
+            else:
+                click.echo(f"The talisman already exists: {key}")
+        elif key_choice.upper() == 'P':
+            key = click.prompt("Reveal the talisman's hiding place (Enter the private key location)")
+        else:
+            click.echo("Invalid choice. No talisman will be set.")
+
+        if key:
+            click.echo("Attempting to bind the talisman with the distant realm...")
+            os.system(f"ssh-copy-id -i {key}.pub {user}@{host}")
+            click.echo(f"The talisman has been bound to {user}@{host}.")
+
     click.echo(f"The winds of magic swirl and solidify; a new passage to '{alias}' has been established.")
     return {"user": user, "host": host, "key": key}
 

--- a/magi_cli/spells/warp.py
+++ b/magi_cli/spells/warp.py
@@ -33,7 +33,7 @@ def warp(ctx, args):
     else:
         # If the alias is not found, go through registration wizard
         if click.confirm(f"Host '{alias}' not found. Would you like to register it?"):
-            register_host(alias, sessions)
+            register_host(alias)
         else:
             click.echo("Operation cancelled.")
 
@@ -49,10 +49,16 @@ def connect_to_host(session):
 
 def register_host(alias, sessions):
     """Register a new SSH session."""
+    click.echo("Starting the registration wizard...")
     host = click.prompt("Enter the host IP or hostname")
     user = click.prompt("Enter the username")
-    password = getpass("Enter the password") if click.confirm("Do you want to set a password?") else None
-    key = click.prompt("Enter the private key location") if click.confirm("Do you want to set a private key?") else None
+    password = None
+    if click.confirm("Do you want to set a password?"):
+        # Use click.prompt with hide_input=True as a fallback for getpass
+        password = click.prompt("Enter the password", hide_input=True)
+    key = None
+    if click.confirm("Do you want to set a private key?"):
+        key = click.prompt("Enter the private key location")
 
     # Add the new session to the .circle file
     sessions[alias] = {

--- a/magi_cli/spells/warp.py
+++ b/magi_cli/spells/warp.py
@@ -13,75 +13,80 @@ CIRCLE_PATH = os.path.join(SANCTUM_PATH, '.circle')
 @click.pass_context
 def warp(ctx, args):
     """ 'wp' - Warp to remote SSH sessions with ease."""
-    # Load the saved SSH sessions from the .circle file
-    if os.path.exists(CIRCLE_PATH):
-        with open(CIRCLE_PATH, 'r') as f:
-            sessions = json.load(f)
-    else:
-        sessions = {}
+    sessions = load_sessions()
 
     if not args:
-        # If no args are provided, show the help message.
-        print(ctx.get_help())
-        return
+        click.echo("Available SSH sessions:")
+        list_sessions(sessions)
+        ctx.exit()
 
     alias = args[0]
 
     if alias in sessions:
-        # If an alias is provided and found, connect to that SSH session
         connect_to_host(sessions[alias])
     else:
-        # If the alias is not found, go through registration wizard
         if click.confirm(f"Host '{alias}' not found. Would you like to register it?"):
-            register_host(alias)
+            # Pass 'sessions' as an argument to 'register_host'
+            register_host(alias, sessions)
+            save_sessions(sessions)
+            click.echo(f"Host '{alias}' registered successfully.")
         else:
             click.echo("Operation cancelled.")
 
+def load_sessions():
+    if os.path.exists(CIRCLE_PATH):
+        with open(CIRCLE_PATH, 'r') as f:
+            return json.load(f)
+    return {}
+
+def save_sessions(sessions):
+    os.makedirs(os.path.dirname(CIRCLE_PATH), exist_ok=True)
+    with open(CIRCLE_PATH, 'w') as f:
+        json.dump(sessions, f, indent=4)
+
+def list_sessions(sessions):
+    for alias, details in sessions.items():
+        click.echo(f"{alias}: {details['user']}@{details['host']}")
+
 def connect_to_host(session):
-    """Connect to a saved SSH session."""
     ssh_command = ['ssh']
-    if 'key' in session:
-        ssh_command.extend(['-i', session['key']])
-    if 'password' in session:
-        ssh_command.extend(['-o', 'PasswordAuthentication=yes'])
+    if session.get('key'):
+        ssh_command += ['-i', session['key']]
+    if session.get('password'):
+        ssh_command += ['-o', 'PasswordAuthentication=yes']
     ssh_command.append(f"{session['user']}@{session['host']}")
     subprocess.run(ssh_command)
 
-def register_host(alias):
+def register_host(alias, sessions):
     """Register a new SSH session."""
     click.echo("Starting the registration wizard...")
     host = click.prompt("Enter the host IP or hostname")
     user = click.prompt("Enter the username")
+    
     password = None
-    key = None
-
     if click.confirm("Do you want to set a password?"):
-        password = click.prompt("Enter the password", hide_input=True, confirmation_prompt=True)
+        try:
+            # Try to use getpass first
+            password = getpass("Enter the password: ")
+        except (EOFError, KeyboardInterrupt):
+            # Use click.prompt as a fallback
+            password = click.prompt("Enter the password", hide_input=True, confirmation_prompt=True)
+    
+    key = None
     if click.confirm("Do you want to set a private key?"):
         key = click.prompt("Enter the private key location")
-
-    # Ensure the .circle file exists
+    
+    # Update and save the .circle file with the new host information
+    sessions[alias] = {"user": user, "host": host, "password": password, "key": key}
     if not os.path.exists(CIRCLE_PATH):
         os.makedirs(os.path.dirname(CIRCLE_PATH), exist_ok=True)
-
-    # Add the new session to the .circle file
-    sessions = {}
-    if os.path.exists(CIRCLE_PATH):
-        with open(CIRCLE_PATH, 'r') as f:
-            sessions = json.load(f)
-
-    sessions[alias] = {
-        "user": user,
-        "host": host,
-        "password": password,
-        "key": key
-    }
-
+    
     with open(CIRCLE_PATH, 'w') as f:
         json.dump(sessions, f, indent=2)
-
     click.echo(f"Host '{alias}' registered successfully.")
 
+
+alias = "wp"
 
 if __name__ == '__main__':
     warp()

--- a/magi_cli/spells/warp.py
+++ b/magi_cli/spells/warp.py
@@ -15,14 +15,14 @@ def warp(ctx, args):
     sessions = load_sessions()
 
     if not args:
-        click.echo("Available SSH sessions:")
+        click.echo("Behold, the available SSH sessions:")
         list_sessions(sessions)
-        selected_session = click.prompt("Select a session number (or press Enter to bypass)", default="")
+        selected_session = click.prompt("Choose a session number (or press Enter to bypass the mystical selection)", default="")
         if selected_session.isdigit() and int(selected_session) <= len(sessions):
             alias = list(sessions.keys())[int(selected_session) - 1]
             connect_to_host(sessions[alias])
         else:
-            click.echo("Bypassing session selection.")
+            click.echo("The arcane forces have granted you passage. Bypassing the mystical session selection.")
         ctx.exit()
 
     alias = args[0]
@@ -30,12 +30,12 @@ def warp(ctx, args):
     if alias in sessions:
         connect_to_host(sessions[alias])
     else:
-        if click.confirm(f"Host '{alias}' not found. Would you like to register it?"):
+        if click.confirm(f"Host '{alias}' not found in your teleportation circle. Would you like to register it and forge a mystical connection?"):
             sessions[alias] = register_host(alias)
             save_sessions(sessions)
-            click.echo(f"Host '{alias}' registered successfully.")
+            click.echo(f"The ancient forces have aligned, and the realm of '{alias}' is now bound to your essence.")
         else:
-            click.echo("Operation cancelled.")
+            click.echo("The arcane energies remain undisturbed. Operation cancelled.")
 
 def load_sessions():
     if os.path.exists(CIRCLE_PATH):
@@ -60,16 +60,16 @@ def connect_to_host(session):
     subprocess.run(ssh_command)
 
 def register_host(alias):
-    """Register a new SSH session."""
-    click.echo("Starting the registration wizard...")
-    host = click.prompt("Enter the host IP or hostname")
-    user = click.prompt("Enter the username")
+    """Register a new SSH session with arcane energies."""
+    click.echo("By the ancient rite of binding, we shall link your essence to another realm...")
+    host = click.prompt("Envision the realm's address (Enter the host IP or hostname)")
+    user = click.prompt("Whisper the name of your alter ego in that realm (Enter the username)")
     
     key = None
-    if click.confirm("Do you want to set a private key?"):
-        key = click.prompt("Enter the private key location")
+    if click.confirm("Do you possess a talisman to bypass the guardians? (Do you want to set a private key?)"):
+        key = click.prompt("Reveal the talisman's hiding place (Enter the private key location)")
     
-    # Update and save the .circle file with the new host information
+    click.echo(f"The winds of magic swirl and solidify; a new passage to '{alias}' has been established.")
     return {"user": user, "host": host, "key": key}
 
 alias = "wp"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,4 @@ Click
 openai
 requests
 Pillow
-python-dotenv
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md', 'r', encoding='utf-8') as f:
 
 setup(
     name='magi_cli_pypi',
-    version='0.1.6',  # Make sure to increment this if you are republishing
+    version='0.1.7',  # Make sure to increment this if you are republishing
     packages=find_packages(),
     package_data={'magi_cli': ['artifacts/*.png']},
     include_package_data=True,
@@ -19,7 +19,9 @@ setup(
         'gitpython',
         'flask',
         'PyQt5',
-        'setuptools'
+        'setuptools',
+        'getpass',
+        'json'
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
         'openai',
         'requests',
         'Pillow',
-        'python-dotenv',
         'gitpython',
         'flask',
         'PyQt5',

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,7 @@ setup(
         'gitpython',
         'flask',
         'PyQt5',
-        'setuptools',
-        'getpass',
-        'json'
+        'setuptools'
     ],
     entry_points={
         'console_scripts': [

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,9 @@ setup(
         'gitpython',
         'flask',
         'PyQt5',
-        'setuptools'
+        'setuptools',
+        'paramiko',
+        'cryptography'
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
- **Warp**: ('**wp**') Warp to remote SSH sessions with ease. This command allows you to manage and connect to SSH sessions effortlessly. It provides a user-friendly interface to register new SSH sessions, edit existing ones, and quickly connect to them. With Warp, you can:
   - List all registered SSH sessions
   - Choose a session to connect to
   - Add a new SSH session by providing the host, username, and optional private key
   - Generate a new RSA key pair for authentication or use an existing private key
   - Delete an existing SSH session and its associated keys
   - Bypass the session selection and directly connect to a session using its alias

- **CONTRIBUTING.md**: Wrote CONTRIBUTING.md to help make it clear how to contribute.

- Also changed file_paths to args everywhere.