### PR TITLE
Pagecraft - Web Scraping Spell

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ Spells are designed with a few things in mind:
 
 11. **Scribe**: ('**sb**') Transcribe the contents of a file or directory into markdown format. This spell captures the essence of your chosen realm, preserving its knowledge in a format easily understood by both mortal and magical beings. You can choose to include or exclude .git directories, and decide whether to etch your transcriptions into the aether (.aether folder in your sanctum) or keep them in the mortal realm (current directory).
 
+12. **Pagecraft**: ('**pgc**') Transform web pages into markdown documents through aether inquiry (AI). This spell fetches content from a URL, uses AI to convert it into well-formatted markdown, and saves it locally. Features include:
+   - Intelligent content extraction and formatting
+   - Multiple review and improvement passes
+   - AI-generated filenames
+   - Configurable save location via SCRAPE_ARCHIVE_PATH
+   - Quality rating and final review
+
 ##### Future Spells
 
 1. **Unseen_Servant**: ('**uss**') Enlist an ethereal ally to cast spells at regular intervals. Can invoke any '.spell' scroll on a schedule. This command schedules a spell to be cast on a regular basis, allowing you to automate tasks by running any '.spell' file on a schedule. (WIP)


### PR DESCRIPTION
This pull request includes an update to the `README.md` file to document a new spell called "Pagecraft". The new spell is designed to transform web pages into markdown documents using AI.

New spell addition:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R63-R69): Added a description for the "Pagecraft" spell, which fetches content from a URL, converts it into markdown using AI, and saves it locally. The description includes features such as intelligent content extraction, multiple review passes, AI-generated filenames, configurable save location, and quality rating.